### PR TITLE
Rayjung ff patch 1

### DIFF
--- a/scripts/maximo_was_dmgr_commands.sh
+++ b/scripts/maximo_was_dmgr_commands.sh
@@ -116,9 +116,11 @@ echo $ssmParameterValue
 
 if [ $ssmParameterValue != "Installed" ];
 then
-  # Deploy the empty database schema and tables
+  # Deploy the demo database schema and tables
+  cd /opt/IBM/SMP/maximo/tools/maximo/en
+  unzip maxdemo.ora.zip
   cd /opt/IBM/SMP/maximo/tools/maximo
-  ./maxinst.sh -sMAXINDEX -tMAXDATA -imaximo
+  ./maxinst.sh -sMAXINDEX -tMAXDATA -imaxdemo
   cd /opt/IBM/SMP/maximo/tools/maximo
   ./updatedb.sh
   /usr/local/bin/aws ssm put-parameter --name "${WASSSMParameter}" --type "String" --value "Installed" --overwrite

--- a/templates/maximo-main.template.yaml
+++ b/templates/maximo-main.template.yaml
@@ -339,10 +339,10 @@ Parameters:
   ORAVersion:
     AllowedValues:
       - Enterprise-Edition-12.2-BYOL
-      - Enterprise-Edition-18.0-BYOL
+      - Enterprise-Edition-19.0-BYOL
       - Standard-Edition-Two-12.2-License-Included
-      - Standard-Edition-Two-18.0-License-Included
-    Default: Standard-Edition-Two-18.0-License-Included
+      - Standard-Edition-Two-19.0-License-Included
+    Default: Standard-Edition-Two-19.0-License-Included
     Description: Amazon RDS Oracle version.
     Type: String
   DBInstanceClass:

--- a/templates/maximo.template.yaml
+++ b/templates/maximo.template.yaml
@@ -315,10 +315,10 @@ Parameters:
   ORAVersion:
     AllowedValues:
       - Enterprise-Edition-12.2-BYOL
-      - Enterprise-Edition-18.0-BYOL
+      - Enterprise-Edition-19.0-BYOL
       - Standard-Edition-Two-12.2-License-Included
-      - Standard-Edition-Two-18.0-License-Included
-    Default: Standard-Edition-Two-18.0-License-Included
+      - Standard-Edition-Two-19.0-License-Included
+    Default: Standard-Edition-Two-19.0-License-Included
     Description: Amazon RDS Oracle version.
     Type: String
   DBInstanceClass:

--- a/templates/oracle.template.yaml
+++ b/templates/oracle.template.yaml
@@ -56,10 +56,10 @@ Parameters:
   ORAVersion:
     AllowedValues:
       - Enterprise-Edition-12.2-BYOL
-      - Enterprise-Edition-18.0-BYOL
+      - Enterprise-Edition-19.0-BYOL
       - Standard-Edition-Two-12.2-License-Included
-      - Standard-Edition-Two-18.0-License-Included
-    Default: Standard-Edition-Two-18.0-License-Included
+      - Standard-Edition-Two-19.0-License-Included
+    Default: Standard-Edition-Two-19.0-License-Included
     Description: Amazon RDS Oracle version
     Type: String
   DBInstanceClass:
@@ -140,21 +140,25 @@ Parameters:
 Mappings:
   OracleDetailsMap:
     Enterprise-Edition-12.2-BYOL:
-      Version: 12.2.0.1.ru-2020-04.rur-2020-04.r1
+      Version: 12.2.0.1.ru-2021-01.rur-2021-01.r1
       Engine: oracle-ee
       Family: oracle-ee-12.2
-    Enterprise-Edition-18.0-BYOL:
-      Version: 18.0.0.0.ru-2020-04.rur-2020-04.r1
+      License: bring-your-own-license
+    Enterprise-Edition-19.0-BYOL:
+      Version: 19.0.0.0.ru-2021-04.rur-2021-04.r1
       Engine: oracle-ee
-      Family: oracle-ee-18
+      Family: oracle-ee-19
+      License: bring-your-own-license
     Standard-Edition-Two-12.2-License-Included:
-      Version: 12.2.0.1.ru-2020-04.rur-2020-04.r1
+      Version: 12.2.0.1.ru-2021-01.rur-2021-01.r1
       Engine: oracle-se2
       Family: oracle-se2-12.2
-    Standard-Edition-Two-18.0-License-Included:
-      Version: 18.0.0.0.ru-2020-04.rur-2020-04.r1
+      License: license-included
+    Standard-Edition-Two-19.0-License-Included:
+      Version: 19.0.0.0.ru-2021-04.rur-2021-04.r1
       Engine: oracle-se2
-      Family: oracle-se2-18
+      Family: oracle-se2-19
+      License: license-included
 
 Resources:
   EncryptionKey:
@@ -289,11 +293,12 @@ Resources:
       DBSubnetGroupName: !Ref 'MaximoDBSubnetGroup'
       Engine: !FindInMap [OracleDetailsMap, !Ref ORAVersion, Engine]
       EngineVersion: !FindInMap [OracleDetailsMap, !Ref ORAVersion, Version]
-      LicenseModel: bring-your-own-license
+      LicenseModel: !FindInMap [OracleDetailsMap, !Ref ORAVersion, License]
       MasterUsername: !Ref 'DBUser'
       MasterUserPassword: !Ref 'DBPassword'
       MultiAZ: !Ref 'DBMultiZone'
       StorageEncrypted: true
+      StorageType: gp2
       KmsKeyId: !GetAtt EncryptionKey.Arn
       VPCSecurityGroups: !Split [ ",", !Join [ ",", [!Ref OracleServerAccessSecurityGroup, !Ref OracleServerSecurityGroup, !Ref OracleServersSecurityGroup, !Ref NodeSecurityGroupID, !Ref ControlPlaneSecurityGroupID] ] ]
   MaximoDBParamGroup:

--- a/templates/was.template.yaml
+++ b/templates/was.template.yaml
@@ -328,6 +328,8 @@ Mappings:
       RHELHVM: ami-031290b4bd9eaa715
     ap-southeast-2:
       RHELHVM: ami-06d2821bfc76dcda3
+    ca-central-1:
+      RHELHVM: ami-0a43efe505004e592
     eu-central-1:
       RHELHVM: ami-0fc86555914f6a9f2
     eu-west-1:


### PR DESCRIPTION
The code was changed to allow for the deployment into the Canadian region. 

In addition, with the deprecation of oracle 18, oracle 19 was used in place. Also with the creation of RDS, the license property to differentiate against BYOL and License-Included. Also, rather than deploy magnetic storage for RDS, the StorageType property for ssd was inserted.

For the demo to be more useful at the start, rather than a blank database be deployed, the cloudformation was edited to allow for the demo maximo database to be deployed. So once completed, the users can log in and see demo data within their dashboard and can be used for conference room pilots for example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
